### PR TITLE
Servicio HMAC Hash configurado

### DIFF
--- a/Backend/HireAProBackend/Controllers/Controlador.cs
+++ b/Backend/HireAProBackend/Controllers/Controlador.cs
@@ -36,6 +36,7 @@ namespace HireAProBackend.Controllers
         private readonly FirestoreDb _firestoreDb;
         public IConfiguration _configuracion;
         private readonly IEmailService _emailService;
+        private readonly IHmacShaHash _hmacShaHash;
 
         public Controlador(FirestoreDb firestoreDb, IConfiguration configuracion, IEmailService emailService)
         {
@@ -414,7 +415,7 @@ namespace HireAProBackend.Controllers
                 return builder.ToString();
             }
         }
-        private string ComputeHMACSha256Hash(string data, string secretKey)
+       private string ComputeHMACSha256Hash(string data, string secretKey)
         {
             var keyBytes = Encoding.UTF8.GetBytes(secretKey);
             using (var hmacsha256 = new HMACSHA256(keyBytes))
@@ -471,7 +472,7 @@ namespace HireAProBackend.Controllers
                 var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.LoginKey));
 
                 //Generar la firma esperada
-                string expectedSignature = ComputeHMACSha256Hash($"{header}.{payload}", jwt.LoginKey);
+                string expectedSignature = _hmacShaHash.ComputeHMACSha256Hash($"{header}.{payload}", jwt.LoginKey);
 
                 //Inicializar las variables para poder utilizarlas después, al validar el 
                 string email = "";

--- a/Backend/HireAProBackend/Controllers/Controlador.cs
+++ b/Backend/HireAProBackend/Controllers/Controlador.cs
@@ -415,16 +415,7 @@ namespace HireAProBackend.Controllers
                 return builder.ToString();
             }
         }
-       private string ComputeHMACSha256Hash(string data, string secretKey)
-        {
-            var keyBytes = Encoding.UTF8.GetBytes(secretKey);
-            using (var hmacsha256 = new HMACSHA256(keyBytes))
-            {
-                var dataBytes = Encoding.UTF8.GetBytes(data);
-                var hashBytes = hmacsha256.ComputeHash(dataBytes);
-                return Convert.ToBase64String(hashBytes).Replace('+', '-').Replace('/', '_').TrimEnd('='); // Convertir a Base64Url
-            }
-        }
+      
 
         [HttpPost("home")] //Comprueba si la firma es correcta pero ha de validar la fecha
         public async Task<ActionResult> ValidateToken([FromBody] Models.AuthenticateRequest authenticateRequest) //Timeout aplicado

--- a/Backend/HireAProBackend/Program.cs
+++ b/Backend/HireAProBackend/Program.cs
@@ -56,7 +56,7 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
-
+builder.Services.AddTransient<IHmacShaHash,HmacShaHash>();
 //Configuracion servicio de correo
 builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddHostedService<DelUsersService>();

--- a/Backend/HireAProBackend/Services/HmacShaHash.cs
+++ b/Backend/HireAProBackend/Services/HmacShaHash.cs
@@ -1,0 +1,19 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+
+namespace HireAProBackend.Services
+{
+    public class HmacShaHash : IHmacShaHash
+    {
+        public string ComputeHMACSha256Hash(string data, string secretKey)
+        {
+            var keyBytes = Encoding.UTF8.GetBytes(secretKey);
+            using (var hmacsha256 = new HMACSHA256(keyBytes))
+            {
+                var dataBytes = Encoding.UTF8.GetBytes(data);
+                var hashBytes = hmacsha256.ComputeHash(dataBytes);
+                return Convert.ToBase64String(hashBytes).Replace('+', '-').Replace('/', '_').TrimEnd('='); // Convertir a Base64Url
+            }
+        }
+    }
+}

--- a/Backend/HireAProBackend/Services/IHmacShaHash.cs
+++ b/Backend/HireAProBackend/Services/IHmacShaHash.cs
@@ -1,0 +1,7 @@
+﻿namespace HireAProBackend.Services
+{
+    public interface IHmacShaHash
+    {
+        string ComputeHMACSha256Hash(string data, string secretKey);
+    }
+}

--- a/Backend/HireAProBackend/obj/Debug/net8.0/HireAProBackend.AssemblyInfo.cs
+++ b/Backend/HireAProBackend/obj/Debug/net8.0/HireAProBackend.AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Reflection;
 [assembly: System.Reflection.AssemblyCompanyAttribute("HireAProBackend")]
 [assembly: System.Reflection.AssemblyConfigurationAttribute("Debug")]
 [assembly: System.Reflection.AssemblyFileVersionAttribute("1.0.0.0")]
-[assembly: System.Reflection.AssemblyInformationalVersionAttribute("1.0.0+432f0357bad4e08472aa3b81b9501ba2db5671b3")]
+[assembly: System.Reflection.AssemblyInformationalVersionAttribute("1.0.0+bc095e619529bc5620b865baac1b5913d3a22fe2")]
 [assembly: System.Reflection.AssemblyProductAttribute("HireAProBackend")]
 [assembly: System.Reflection.AssemblyTitleAttribute("HireAProBackend")]
 [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]


### PR DESCRIPTION
**Cambios:**
- Configurada la interfaz y el servicio para el HMAC Hash (usado en los tokens)
- Inyectado el servicio en el controlador
- Eliminada la función del controlador para mantener el código más limpio

**Falta:**
- Configurar el servicio de Hash
- Configurar el servicio de generación de tokens (no jwt)